### PR TITLE
Fix spec work

### DIFF
--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_amendapply/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_amendapply/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/reference/9002015000248266
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/reference/9002015000248266"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:
@@ -94,7 +96,7 @@ http_interactions:
   recorded_at: Thu, 25 Jun 2015 05:17:33 GMT
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/amendapply
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/amendapply"
     body:
       encoding: UTF-8
       string: |
@@ -216,6 +218,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_amends/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_amends/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/amend/9002015000243941
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/amend/9002015000243941"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_apply/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_apply/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/apply
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/apply"
     body:
       encoding: UTF-8
       string: |
@@ -126,6 +126,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_arrived_applications/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_arrived_applications/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/apply/201503090951504109
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/apply/201503090951504109"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_banks/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_banks/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/bank
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/bank"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_comment/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_comment/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/comment/9002015000243928/1
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/comment/9002015000243928/1"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_done_comment/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_done_comment/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/comment
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/comment"
     body:
       encoding: UTF-8
       string: |
@@ -14,6 +14,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_done_officialdocument/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_done_officialdocument/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/officialdocument
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/officialdocument"
     body:
       encoding: UTF-8
       string: |
@@ -14,6 +14,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_notices/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_notices/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/notice/9002015000243928
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/notice/9002015000243928"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_officialdocument/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_officialdocument/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/officialdocument/9002015000243931/1
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/officialdocument/9002015000243931/1"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_partamend/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_partamend/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/partamend
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/partamend"
     body:
       encoding: UTF-8
       string: |
@@ -126,6 +126,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_payments/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_payments/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/payment/9002015000243934
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/payment/9002015000243934"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_reamend/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_reamend/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/reamend
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/reamend"
     body:
       encoding: UTF-8
       string: |
@@ -124,6 +124,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_reference/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_reference/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/reference/9002015000243941
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/reference/9002015000243941"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_sended_applications_by_date/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_sended_applications_by_date/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/apply;date=20150301-20150310
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/apply;date=20150301-20150310"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_sended_applications_by_id/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_sended_applications_by_id/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/apply;id=201503090951504109
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/apply;id=201503090951504109"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_verify_officialdocument/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_verify_officialdocument/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/officialdocument/9002015000243931/2
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/officialdocument/9002015000243931/2"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:
@@ -51,7 +53,7 @@ http_interactions:
   recorded_at: Tue, 28 Apr 2015 02:45:04 GMT
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/officialdocument/verify
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/officialdocument/verify"
     body:
       encoding: UTF-8
       string: |
@@ -67,6 +69,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Access/_withdraw/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Access/_withdraw/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/apply;id=201504281051005638
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/apply;id=201504281051005638"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:
@@ -86,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 28 Apr 2015 02:45:02 GMT
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/access/withdrawal
+    uri: "<EGOV-API-END-POINT>shinsei/1/access/withdrawal"
     body:
       encoding: UTF-8
       string: |
@@ -189,6 +191,8 @@ http_interactions:
           </ApplData>
         </DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Authentication/_append_certificate/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Authentication/_append_certificate/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,13 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/user
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/user"
     body:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <DataRoot><ApplData Id="ApplData"><UserID>150428114508</UserID></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114508"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>EiquUyCbD/sPUkisymT67RBLKniJdGImf7XH6SBHf0M=</DigestValue></Reference></SignedInfo><SignatureValue>gbWAprCDxlaCWcSITxTJU86wXF+ozzAHd5b22CNcJAnRsBkvClouPjUat2a8cWih0WP+y5QnL8ChvKN0APdWP9zHhOBgbHgnprn9TmxYQ7IIjyA4IafANzRlyATgFaNRr1oAREOCQLz9ucA+9P8fBdG6WFerQgzNqMrvhJGgdwuyVr0WtlBcvBlf9AICaFd8MEX6fymUCSpRkw3BmLCPxDj7A+LXj/zbL4wUphR7/NMlBydLHNkq2i9L0hhN3Y/1sNuTnZ0ywzX1UNRgffHH8M7m51nFEDm0m9J5cNxRyTNaeazx9EkBXVLkBjUFe8R9OGbdRcMsgABsFVPd7Z20xA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:
@@ -61,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 28 Apr 2015 02:45:09 GMT
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/certificate/append
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/certificate/append"
     body:
       encoding: UTF-8
       string: |
@@ -94,6 +96,8 @@ http_interactions:
         cLsyXTQTJJifppZ45CiyxrqwjJp1I0EfNmWtGRj93/XAutaqJk73Sg==
         </AddX509Certificate></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114509"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>kgjUnAYJybQK3bZLhmcKp1+tCZRbD1TTDsvoVGHxcsc=</DigestValue></Reference></SignedInfo><SignatureValue>NVs8RCd5Sr+TqO0vsVjUrLNXNXmD5YTWZegceiHEAjdej0XFyO7adelvlbjMfuryxyW0V5M+R0ri+903HCAmKGFfhOTy2BRTT5663NsQQi3ztTJsUlL5urCwsrEC1G1b2sZa5jV4NwE4YrcCL+Qrkomx2m5iqtXONm6BQQIDRX9dLZodO3xw1kJq/3grUzHdaS8/AZ44j5uQRbhxH1dRaMROAs1+wskh4C7yxnXoZWQm/29vmFBTdKRidDg2bbxlaohlYihcwGPPQFOpcchFbOXFwc4CadF7p8VEzV17B9HwQITuuS1BpsDNqmDubG3RYz9Av1aodrZbwVyx9PJVPw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Authentication/_delete_certificate/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Authentication/_delete_certificate/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,13 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/user
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/user"
     body:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <DataRoot><ApplData Id="ApplData"><UserID>150428114512</UserID></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114512"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>kP1rcCgy4GKenVjr6urqG1/+VziCOid+PJ3H03sbmjY=</DigestValue></Reference></SignedInfo><SignatureValue>cK3sH5Vgu+cjT0afmw9tbpxwfkMqsb67Vm57uldpRU0mLq5MmuWjrs/ilBXjpbmQnif43xoG/wqaq7Qb7CQinNqwoPduGNV8Bp2W5ttadDT8jsy1iQtaLDA+zROWPmJbNPilNJ87vQ4va00354MhpA0QqpaRGCAtMeclPB1+3bgNKn9+LEFMwy1I2K4u0+5IlCyqrhUGhgBygzkU9ItFCaXOyxGQqG3n8Cl4o+D6tMgfsKRhV5q1nwXEAjPaBgRlBLB3HO39MXvL+s/tCOTAKceY3t7qCAmk5Qn793cStNV7C5SBCynHf9PZDyIJbPPwqHxk+4UrK+4H9Io6FaIbIw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:
@@ -61,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 28 Apr 2015 02:45:12 GMT
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/certificate/append
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/certificate/append"
     body:
       encoding: UTF-8
       string: |
@@ -94,6 +96,8 @@ http_interactions:
         cLsyXTQTJJifppZ45CiyxrqwjJp1I0EfNmWtGRj93/XAutaqJk73Sg==
         </AddX509Certificate></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114512"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>/gxJ4fpNv3Qe2ompqddXy1rgCTutQssib+PWN6a4yKo=</DigestValue></Reference></SignedInfo><SignatureValue>OAezbaWJhXoSmD0mdaA7IA+LYVwrbLu7koUCO08e3J3QkxLNbeq1ON3I49VqHGkXsjko6+Atf8NpH7cduZ7kQFdLLLfqzHWDf676va55QWaJrRt28HCjLtvOGKPXMCjs6m4+mNrICwQl/AH2JbXfqOu/Bw/nkNTZnFtdjziO8WjdArDMLRmBsx3G1UkhQI96wR51b0+RRhqDdro4uBg3Du06/9k0CJnIEkkxQpwDbY/XJyL3+I4zpT601mFUQ7LEzK68+wQpN/oqHyrNdG+2Iqju/uQ7XS07UHNWcJw6z4d21um/VsGbFSbauGEHTKmF2vJy14m/rjbIYxClWDFqxQ==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:
@@ -147,7 +151,7 @@ http_interactions:
   recorded_at: Tue, 28 Apr 2015 02:45:13 GMT
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/certificate/delete
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/certificate/delete"
     body:
       encoding: UTF-8
       string: |
@@ -180,6 +184,8 @@ http_interactions:
         cLsyXTQTJJifppZ45CiyxrqwjJp1I0EfNmWtGRj93/XAutaqJk73Sg==
         </DelX509Certificate></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114513"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>KXdHEwH0Z5mWW4rlBKkUQ5Ayn09dtCaM7Yh2j/lAPbw=</DigestValue></Reference></SignedInfo><SignatureValue>HKLzWfr1VLzIdUsuyzhVGM+sVoanZX6ISiGoKpFJcXI+pSsdVdiR3tqzhQUxR0xQubCsXeRojlSr8e/kLh1NUQg3susRYx3xCVt63XdVXf8aAEgBxBW9SekD8Jhd+izoyc7fm4PE9L2oxZjcoiXa1gSRBJAWGqdEE6Zrq3l7pUbhNJsyrC82GluZBw0DsNsPRl8t+m5gztpUfvBhxzebIu9D/obuaaJoysrLYb9wyiEIqSEX28KOToaLqIf124/aoLVgr51B9DSV5QqY5AJTF7TegRTtG66NOQ1n9aONlLo6LAs1/cN88uWbyk3Z1uz+en2zQ3BAQrarfmfZcF/1bg==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Authentication/_login/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Authentication/_login/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,13 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/login
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/login"
     body:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <DataRoot><ApplData Id="ApplData"><UserID><EGOV-TEST-USER-ID></UserID></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114507"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>V//B0sP2jNsl+Heiy0sNsCR2B3P6gjtOzsfvEO8868g=</DigestValue></Reference></SignedInfo><SignatureValue>EXiX+wVNsJ/xflESNLzBfVb2HpPdCX8Rq3cuYqz5tWfkxKqtvI6oImeoWLr0SWYfWdHzdSBfNCEYbBrjCZzAB/DG3fstU5NtkSIcWy/gPxXCnvwZAk7fiFqUFPdBL6YmsHnjY5cymKHXGm//RnMj3DabJOWeHWMD0K4B6bch5Ar2dyqWTCx/u1OkLkuPmKyaRNwuxyrbBhV8HkjVqfAnd/mzK+Py9eYmv1lqw6VSX2lh607BEgdGMxjasPgi6tNrnVME9SwX0IxSCsvDUy/ET4bNw409Y+YuX1gzaD2cO3NHlO5l0MEzka+rXTYKW66t5GS0cZckHnooytzGoUoGow==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Authentication/_register/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Authentication/_register/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,13 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/user
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/user"
     body:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <DataRoot><ApplData Id="ApplData"><UserID>150428114507</UserID></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114507"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>hwpo8GzrI8J1v3fdqXUa3R/IiS4caR43kHmik6zX688=</DigestValue></Reference></SignedInfo><SignatureValue>KrhIPJ6xKVD5QAPJCSx0n7btVSPnjUe+xMqMPTfaueikj6zcjGsSZNPhaQXPrSl78Dxo6wDFw4NaEZBroUchbXUidUgul4Kiue+ReL/LwR+Pjrg0mN/LNRH1v66bzuWLuJcoq+X6yGuEdhq+L9/6A3RKvQMGTK7BXcFSOZsRlpBqJJE5HBYYU/GgpXXLhz+0G6A+8m0+dK6YJh/MgwpOfgk7TKXy3a93/el9tmgm71PzqXJb3FnnXWoJLumnm69iZZTkVnmxU30405TFilL1tjPIFUI5SHh8qZ0QixkafNbxQWP2cAhfifoF/jxycH/542N6Asov8BPBjBWo8eLo7Q==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/Kiji_Authentication/_update_certificate/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
+++ b/spec/fixtures/vcr_cassettes/Kiji_Authentication/_update_certificate/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/certificate/update
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/certificate/update"
     body:
       encoding: UTF-8
       string: |
@@ -35,6 +35,8 @@ http_interactions:
         l3JAJhWGruMztGbZIiRhPWSkeJK1XHnqRRNyqpcURdhXI/p+mf9qczs=
         </X509Certificate></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150428114510"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>Ju66lxWDYsGQePVPupud2GNOXEmm8fnpWSQk7WaFb5E=</DigestValue></Reference></SignedInfo><SignatureValue>R/WmDvAmMrht6SJtUcG2YDBXqyDfToi2SMgenT+nxxqBD6V9VXVePDloSzm4EFpOUFDt1w1a+/ZiyOaBWNA8mQqggqC10nakl/Icl8r+2St3ifioGeLRE6eKVA7DoQl0DNdySpYtnVe1tNS0Hga9GCgyUVZ2m85Ah8uUx6+BWeA=</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEBjCCAu6gAwIBAgIEVHXa0TANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNTAzMTMwMTIxMjdaFw0yMDAzMTIxNDU5NTlaMEgxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRgwFgYDVQQDDA9TaGlybyBNYWRvZ3VjaGkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAJlONNuV73WMPCtbXwnn+iAlN5Nb+yN+SEtlBD2BJg9VEaEZOX1b7gXLA9vUqSf80EaFRrxND7r7vgC3UAyen2/8s8CtlELMF8A4m5UN4cFQKXF8eVkD2lv4E/p0Z8rLCh/jlfEAuzaBnAelFpj3/9SiyriQ8gtlsz7H9nKH1H2hAgMBAAGjggGUMIIBkDAOBgNVHQ8BAf8EBAMCBsAwEQYJYIZIAYb4QgEBBAQDAgZAME4GA1UdEgRHMEWkQzBBMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJEwHwYDVR0gAQH/BBUwEzARBg8CgziGjjEIAQEAAoybJWQwaAYDVR0RBGEwX6RdMFsxCzAJBgNVBAYTAkpQMR4wHAYDVQQKDBXmqKHmk6zmsJHplpPoqo3oqLzlsYAxEjAQBgNVBAsMCe+8o++8oe+8kTEYMBYGA1UEAwwP56qT5Y+j44CA5Zub6YOOMFAGA1UdHwRJMEcwRaBDoEGkPzA9MQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTENMAsGA1UEAwwEQ1JMMTAfBgNVHSMEGDAWgBQU0+eW9FLHxcU6dGUu6Zb3mHgjXzAdBgNVHQ4EFgQUvh4NrNOuDVi3q/Cgv4dz9bKrUqswDQYJKoZIhvcNAQELBQADggEBADX0c/7oW06h3nQdvUD+ih6BPszFi0jahi1X10+XRWUBC3hOiryKnaiBnZrL0PfzGcTIe+FbmJvpRR629YngbXJ8rxB+7Tl6w3J2YlERJ/jrj6qldoMbyPNyUkoFnuYnh2M9/Fw1r/L0HOLwaLgoUErr0aaVsneklOvRVEfTOUzQ+WiCOaQAulCM3Hb9NwEQDZHUaCQT//9xoYp2Be0FIB46cM1tEwc4c+pTOQ4Dvhb+aW5FxTYE1PsrwG2sAFHOB81SZ6A8trsndUtDcxtGh9yDigc6ISi/3V4FJpNCl6/JlH0foJmvcFdVEPOGH7gOOCX1b9VXK1iT16VyPCHlGUQ=</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/fixtures/vcr_cassettes/my_client_login.yml
+++ b/spec/fixtures/vcr_cassettes/my_client_login.yml
@@ -2,13 +2,15 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<EGOV-SOFTWARE-ID>:<EGOV-BASIC-AUTH-PASSWORD>@api2.kn.e-gov.go.jp/shinsei/1/authentication/login
+    uri: "<EGOV-API-END-POINT>shinsei/1/authentication/login"
     body:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <DataRoot><ApplData Id="ApplData"><UserID><EGOV-TEST-USER-ID></UserID></ApplData><Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="20150617091628"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#ApplData"><Transforms><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>V//B0sP2jNsl+Heiy0sNsCR2B3P6gjtOzsfvEO8868g=</DigestValue></Reference></SignedInfo><SignatureValue>EXiX+wVNsJ/xflESNLzBfVb2HpPdCX8Rq3cuYqz5tWfkxKqtvI6oImeoWLr0SWYfWdHzdSBfNCEYbBrjCZzAB/DG3fstU5NtkSIcWy/gPxXCnvwZAk7fiFqUFPdBL6YmsHnjY5cymKHXGm//RnMj3DabJOWeHWMD0K4B6bch5Ar2dyqWTCx/u1OkLkuPmKyaRNwuxyrbBhV8HkjVqfAnd/mzK+Py9eYmv1lqw6VSX2lh607BEgdGMxjasPgi6tNrnVME9SwX0IxSCsvDUy/ET4bNw409Y+YuX1gzaD2cO3NHlO5l0MEzka+rXTYKW66t5GS0cZckHnooytzGoUoGow==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEizCCA3OgAwIBAgIEVHXPfTANBgkqhkiG9w0BAQsFADAuMQswCQYDVQQGEwJKUDERMA8GA1UECgwIRGVtb01pbjExDDAKBgNVBAsMA0NBMTAeFw0xNDExMjgwNjAxMDJaFw0xOTExMjcxNDU5NTlaMEkxCzAJBgNVBAYTAkpQMREwDwYDVQQKDAhEZW1vTWluMTEMMAoGA1UECwwDQ0ExMRkwFwYDVQQDDBBJY2hpcm8gTWFkb2d1Y2hpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyJBITKzWETx6waZ4cTuhM0rThzTM2tzIUH1Pbq6UbeUE/sjDAUGs5RxIWCugtORajYOnoBSCV3rJE/oMdo5NJkUU2xtI0t4+0GXWNVeomUGT4RG4O3/ctJvL/WkgH7d+WUb8CeUjSSVqQCPxdJehuIxZSgL0lqASovuHYfvblB8DsAMNlhqLZWDxdy8xp25o+N9+iiS0z5LIHF2D6xnnIxv59SY3A49GUMVeBopI5tIRkZG1ahCJTYEAvcJioEXPP8R9OBIOGiWGxXdoXIJmKsyxGZ5XsC+gx4J/zf4U8UJWfSkfpQREbInC+n9T9hFIBpDzrdDBT1BW4vZTQGtj4QIDAQABo4IBlDCCAZAwDgYDVR0PAQH/BAQDAgbAMBEGCWCGSAGG+EIBAQQEAwIGQDBOBgNVHRIERzBFpEMwQTELMAkGA1UEBhMCSlAxHjAcBgNVBAoMFeaooeaTrOawkemWk+iqjeiovOWxgDESMBAGA1UECwwJ77yj77yh77yRMB8GA1UdIAEB/wQVMBMwEQYPAoM4ho4xCAEBAAKMmyVkMGgGA1UdEQRhMF+kXTBbMQswCQYDVQQGEwJKUDEeMBwGA1UECgwV5qih5pOs5rCR6ZaT6KqN6Ki85bGAMRIwEAYDVQQLDAnvvKPvvKHvvJExGDAWBgNVBAMMD+eqk+WPo+OAgOS4gOmDjjBQBgNVHR8ESTBHMEWgQ6BBpD8wPTELMAkGA1UEBhMCSlAxETAPBgNVBAoMCERlbW9NaW4xMQwwCgYDVQQLDANDQTExDTALBgNVBAMMBENSTDEwHwYDVR0jBBgwFoAUFNPnlvRSx8XFOnRlLumW95h4I18wHQYDVR0OBBYEFHS3bhJrJpfwWCRG6XOCpfnv6YZWMA0GCSqGSIb3DQEBCwUAA4IBAQBGJqT07F70WP2xJoFyLZu3aB5g9FnT2zrd5gcB7VzIlB14B48tCSFRL+mXicacsnu8JX5vdah9TBeJ8FgzTNWgkr8QVKAEymA7KZOktlRlrLMaHqPKJVIKOZHQJxfrqznGLOetbALnslQwU9EVyjCMSnFH3Gdh2JqsQP9y9lRt+tPEehAv7eTZmQ+MYCQrSXX2VAbXUrHxEWdjWwlPzFHQrNlVOpaAlVu9CnNZoBgk09IMkTJ3p5TjOY9UZcK/3p0B3iksWt10cWJ4GE+IrjNSu+ZxLYR5Ld4vYNtIL7cLEUw1CbB334JBH9vT8mTo54kdGVB4ZOix5lkog3PJnoAF</X509Certificate></X509Data></KeyInfo></Signature></DataRoot>
     headers:
+      Authorization:
+      - "<AUTHORIZATION>"
       User-Agent:
       - SmartHR v0.0.1
       X-Egovapi-Softwareid:

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -16,6 +16,9 @@ VCR.configure do |config|
   config.filter_sensitive_data('<X-EGOVAPI-ACCESSKEY>') do |interaction|
     interaction.request.headers['X-Egovapi-Accesskey'].first if interaction.request.headers['X-Egovapi-Accesskey']
   end
+  config.filter_sensitive_data('<AUTHORIZATION>') do |interaction|
+    interaction.request.headers['Authorization'].first if interaction.request.headers['Authorization']
+  end
   config.filter_sensitive_data('<SET-COOKIE>') do |interaction|
     interaction.response.headers['Set-Cookie'].first if interaction.response.headers['Set-Cookie']
   end


### PR DESCRIPTION
## Description
Currently, the spec does not work with the following error.
I made the spec work.

<details>
<summary>rspec error sample</summary>

```bash
  1) Kiji::Access#apply behaves like call the API w/ VALID parameter should return valid response
     Failure/Error:
       connection.post('/shinsei/1/authentication/login') do |req|
         req.body = sign(appl_data).to_xml
       end
     
     VCR::Errors::UnhandledHTTPRequestError:
     
     
       ================================================================================
       An HTTP request has been made that VCR does not know how to handle:
         POST https://api2.kn.e-gov.go.jp/shinsei/1/authentication/login
     
       VCR are currently using the following cassettes:
         - /kiji/spec/fixtures/vcr_cassettes/my_client_login.yml
           - :record => :once
           - :match_requests_on => [:method, :uri]
         - /kiji/spec/fixtures/vcr_cassettes/Kiji_Access/_apply/behaves_like_call_the_API_w/_VALID_parameter/should_return_valid_response.yml
           - :record => :once
           - :match_requests_on => [:method, :uri]
     
       Under the current configuration VCR can not find a suitable HTTP interaction
       to replay and is prevented from recording new requests. There are a few ways
       you can deal with this:
     
         * If you're surprised VCR is raising this error
           and want insight about how VCR attempted to handle the request,
           you can use the debug_logger configuration option to log more details [1].
         * You can use the :new_episodes record mode to allow VCR to
           record this new request to the existing cassette [2].
         * If you want VCR to ignore this request (and others like it), you can
           set an `ignore_request` callback [3].
         * The current record mode (:once) does not allow new requests to be recorded
           to a previously recorded cassette. You can delete the cassette file and re-run
           your tests to allow the cassette to be recorded with this request [4].
         * The cassette contains 2 HTTP interactions that have not been
           played back. If your request is non-deterministic, you may need to
           change your :match_requests_on cassette option to be more lenient
           or use a custom request matcher to allow it to match [5].
     
       [1] https://www.relishapp.com/vcr/vcr/v/5-0-0/docs/configuration/debug-logging
       [2] https://www.relishapp.com/vcr/vcr/v/5-0-0/docs/record-modes/new-episodes
       [3] https://www.relishapp.com/vcr/vcr/v/5-0-0/docs/configuration/ignore-request
       [4] https://www.relishapp.com/vcr/vcr/v/5-0-0/docs/record-modes/once
       [5] https://www.relishapp.com/vcr/vcr/v/5-0-0/docs/request-matching
       ================================================================================
     Shared Example Group: "call the API w/ VALID parameter" called from ./spec/kiji/access_spec.rb:13
     # ./lib/kiji/authentication.rb:26:in `login'
     # ./spec/support/api_helper.rb:36:in `block (3 levels) in <top (required)>'
     # ./spec/support/api_helper.rb:35:in `block (2 levels) in <top (required)>'
     # ./spec/kiji/access_spec.rb:11:in `block (3 levels) in <top (required)>'
     # ./spec/support/api_helper.rb:4:in `block (2 levels) in <top (required)>'
```
</details>


### Details
* remove Basic Auth credentials from request uri.
* mask Authorization data in request headers.

## Why spec does not work?
* From v2.0.0, webmock does not match basic auth credentials in the userinfo part of the url.
  * https://github.com/bblimke/webmock/blob/2.0/CHANGELOG.md#200
* Maybe, VCR Cassette was recorded before WebMock v2.0.0. URL include basic auth credentials.
