### PR TITLE
Fix spec on GitHub actions

### DIFF
--- a/spec/kiji/authentication_spec.rb
+++ b/spec/kiji/authentication_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe Kiji::Authentication do
   include_context 'setup client'
 
+  around do |example|
+    Dir.mktmpdir('rspec-') do |dir|
+      @temp_dir = dir
+      example.run
+    end
+  end
+
   describe '#register', :vcr do
     let(:expected_status_code) { 201 }
     let(:response) do

--- a/spec/kiji/zipper_spec.rb
+++ b/spec/kiji/zipper_spec.rb
@@ -16,7 +16,7 @@ def create_zip(procedure_id, app_file_names = [], tenpu_file_names = [])
   signer = zipper.sign(kousei_base_file_path, app_file_paths)
 
   # 出力
-  base_dir              = "tmp/ikkatsu/#{procedure_id}"
+  base_dir              = "#{@temp_dir}/ikkatsu/#{procedure_id}"
   application_dir       = "#{base_dir}/#{procedure_id}(1)"
 
   # 申請案件フォルダの作成
@@ -36,10 +36,17 @@ def create_zip(procedure_id, app_file_names = [], tenpu_file_names = [])
   end
 
   # zip に固める
-  zipper.write_zip(base_dir, "tmp/#{procedure_id}.zip")
+  zipper.write_zip(base_dir, "#{@temp_dir}/#{procedure_id}.zip")
 end
 
 describe Kiji::Zipper do
+  around do |example|
+    Dir.mktmpdir('rspec-') do |dir|
+      @temp_dir = dir
+      example.run
+    end
+  end
+
   describe 'create_zip' do
     # ＡＰＩテスト用手続（労働保険関係手続）（通）０００１／ＡＰＩテスト用手続（労働保険関係手続）（通）０００１
     it '900A010200001000' do

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -16,7 +16,7 @@ shared_context 'setup client' do
   let(:my_client) do
     Kiji::Client.new do |c|
       c.software_id = ENV['EGOV_SOFTWARE_ID']
-      c.api_end_point = ENV['EGOV_API_END_POINT']
+      c.api_end_point = ENV.fetch('EGOV_API_END_POINT', 'http://example.com/')
       c.basic_auth_id = ENV['EGOV_BASIC_AUTH_ID']
       c.basic_auth_password = ENV['EGOV_BASIC_AUTH_PASSWORD']
     end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,7 +1,7 @@
 shared_examples_for 'call the API w/ VALID parameter' do
   it 'should return valid response' do
     method_name = RSpec.current_example.metadata[:example_group][:parent_example_group][:description]
-    File.write("tmp/responses/response_#{method_name}.txt", response.body)
+    File.write("#{@temp_dir}/response_#{method_name}.txt", response.body)
 
     xml = Nokogiri::XML(response.body)
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,7 +9,7 @@ VCR.configure do |config|
   #   re_record_interval: 60 * 60 * 24 # 1 day
   # }
   config.filter_sensitive_data('<EGOV-SOFTWARE-ID>') { ENV['EGOV_SOFTWARE_ID'] }
-  config.filter_sensitive_data('<EGOV-API-END-POINT>') { ENV['EGOV_API_END_POINT'] }
+  config.filter_sensitive_data('<EGOV-API-END-POINT>') { ENV.fetch('EGOV_API_END_POINT', 'http://example.com/') }
   config.filter_sensitive_data('<EGOV-TEST-USER-ID>') { ENV['EGOV_TEST_USER_ID'] }
   config.filter_sensitive_data('<EGOV-BASIC-AUTH-ID>') { ENV['EGOV_BASIC_AUTH_ID'] }
   config.filter_sensitive_data('<EGOV-BASIC-AUTH-PASSWORD>') { ENV['EGOV_BASIC_AUTH_PASSWORD'] }


### PR DESCRIPTION
## Description
I introduced Github Actions in #29.
However, the test was failing, so I will fix it.

## Changes
* Set Default value to `ENV['EGOV_API_END_POINT']`
  * EGOV_API_END_POINT is required for spec.
* Use tmpdir.
  * Currently, we have to create a separate temporary folder, and the data remains even after the test is over.
  * One test is dependent on a file created by another test.