### PR TITLE
fix gemfile comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in egov.gemspec
+# Specify your gem's dependencies in kiji.gemspec
 gemspec


### PR DESCRIPTION
I noticed that old product name `egov` is written as comment on Gemfile.
I think it is forgotten by https://github.com/kufu/kiji/pull/16/commits/aa251e2e648e39999ea712af5da9f6c1081b16ec.

Feel free to close if it's best left as-is.