### PR TITLE
Drop Ruby 2.6 support and specify minimum target version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - 2.6
           - 2.7
           - '3.0' # Quoted, to avoid YAML float 3.0 interplated to "3"
           - 3.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: '.rubocop_todo.yml'
 
+AllCops:
+  TargetRubyVersion: 2.7
+
 Style/AsciiComments:
   Enabled: false
 

--- a/kiji.gemspec
+++ b/kiji.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.7'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'guard'


### PR DESCRIPTION
 Ruby 2.6 has now reached EOL.